### PR TITLE
freeze the Firefox version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "node"
 addons:
-  firefox: "latest"
+  firefox: "42.0"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Our testing environment shouldn’t change underneath us. Freeze the Firefox version and we’ll update Firefox versions manually.
