### PR TITLE
changing the bundle type produced by webpack in development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 var path = require('path');
 module.exports = {
-    devtool: 'eval',
+    devtool: 'cheap-module-eval-source-map',
     entry: [
         'webpack-hot-middleware/client?reload=true',
         "./example/example.js"


### PR DESCRIPTION
this should give us better sourcemaps

I can’t believe I hadn’t known this existed before…