### PR TITLE
starting to add another type of label option for parts/features in RowItem

### DIFF
--- a/src/RowItem/Labels.js
+++ b/src/RowItem/Labels.js
@@ -6,14 +6,14 @@ import IntervalTree from "node-interval-tree";
 import getYOffset from "../CircularView/getYOffset";
 import forEach from "lodash/forEach";
 
-function CutsiteLabels(props) {
+function Labels(props) {
   let {
     annotationRanges = {},
     bpsPerRow,
     charWidth,
     annotationHeight,
-    onClick,
-    onRightClick,
+    // onClick,
+    // onRightClick,
     textWidth = 10,
     editorName
   } = props;
@@ -21,15 +21,16 @@ function CutsiteLabels(props) {
     return null;
   }
   let warningMessage = null;
-  if (Object.keys(annotationRanges).length > 50) {
-    warningMessage = (
-      <span style={{ color: "red" }}>
-        <br />
-        Warning: Only the first 50 cutsites will be displayed. Filter the
-        cutsites you wish to see using the filter tool <br />
-      </span>
-    );
-  }
+  // if (Object.keys(annotationRanges).length > 50) {
+  //   warningMessage = (
+  //     <span style={{ color: "red" }}>
+  //       <br />
+  //       Warning: Only the first 50 cutsites will be displayed. Filter the
+  //       cutsites you wish to see using the filter tool <br />
+  //     </span>
+  //   );
+  // }
+
   let rowLength = bpsPerRow * charWidth;
   let counter = 0;
   let maxAnnotationYOffset = 0;
@@ -43,7 +44,8 @@ function CutsiteLabels(props) {
     if (!annotation) {
       annotation = annotationRange;
     }
-    let annotationLength = annotation.restrictionEnzyme.name.length * textWidth;
+    let annotationLength =
+      (annotation.name || annotation.restrictionEnzyme.name).length * textWidth;
     let { xStart } = getXStartAndWidthOfRowAnnotation(
       annotationRange,
       bpsPerRow,
@@ -68,15 +70,15 @@ function CutsiteLabels(props) {
     }
     let height = yOffset * annotationHeight;
     annotationsSVG.push(
-      <DrawCutsiteLabel
+      <DrawLabel
         id={annotation.id}
         key={"cutsiteLabel" + index}
         {...{
           editorName,
           annotation,
           xStartOriginal,
-          onClick,
-          onRightClick,
+          onClick: annotationRange.onClick,
+          onRightClick: annotationRange.onRightClick,
           height,
           xStart
         }}
@@ -109,9 +111,9 @@ export default onlyUpdateForKeys([
   "onClick",
   "textWidth",
   "editorName"
-])(CutsiteLabels);
+])(Labels);
 
-const DrawCutsiteLabel = withHover(
+const DrawLabel = withHover(
   ({
     hovered,
     className,
@@ -151,7 +153,7 @@ const DrawCutsiteLabel = withHover(
             // left: '100 % ',
           }}
         >
-          {annotation.restrictionEnzyme.name}
+          {annotation.name || annotation.restrictionEnzyme.name}
         </div>
         {hovered && (
           <div

--- a/src/RowItem/index.js
+++ b/src/RowItem/index.js
@@ -3,8 +3,7 @@ import {
   getSequenceWithinRange,
   getOverlapsOfPotentiallyCircularRanges
 } from "ve-range-utils";
-import { map, camelCase, startCase, startsWith } from "lodash";
-import flatMap from "lodash/flatMap";
+import { map, camelCase, startCase, startsWith, flatMap, assign } from "lodash";
 import { getComplementSequenceString } from "ve-sequence-utils";
 import React from "react";
 import pluralize from "pluralize";
@@ -14,7 +13,7 @@ import Axis from "./Axis";
 import Orfs from "./Orfs";
 import Translations from "./Translations";
 
-import CutsiteLabels from "./CutsiteLabels";
+import Labels from "./Labels";
 import Cutsites from "./Cutsites";
 import Caret from "./Caret";
 import StackedAnnotations from "./StackedAnnotations";
@@ -91,6 +90,10 @@ export class RowItem extends React.PureComponent {
       translationDoubleClicked = noop,
       cutsiteClicked = noop,
       cutsiteRightClicked = noop,
+      featureClicked = noop,
+      featureRightClicked = noop,
+      partClicked = noop,
+      partRightClicked = noop,
       minHeight = 22,
       bpsPerRow = sequenceLength,
       editorName
@@ -100,6 +103,8 @@ export class RowItem extends React.PureComponent {
       chromatogram: showChromatogram,
       // orfLabels: showOrfLabel,
       cutsites: showCutsites,
+      features: showFeatures,
+      parts: showParts,
       cutsitesInSequence: showCutsitesInSequence,
       axis: showAxis,
       axisNumbers: showAxisNumbers,
@@ -109,8 +114,12 @@ export class RowItem extends React.PureComponent {
       reverseSequence: showReverseSequence,
       sequence: showSequence
     } = annotationVisibility;
-    let { cutsites: showCutsiteLabels = true } = annotationLabelVisibility;
-    let { sequence = "", cutsites = [] } = row;
+    let {
+      cutsites: showCutsiteLabels = true,
+      features: showFeatureLabels = true,
+      parts: showPartLabels = true
+    } = annotationLabelVisibility;
+    let { sequence = "", cutsites = [], features = [], parts = [] } = row;
 
     let reverseSequence = getComplementSequenceString(
       (alignmentData && alignmentData.sequence) || sequence
@@ -319,17 +328,40 @@ export class RowItem extends React.PureComponent {
             onDoubleClick: translationDoubleClicked
           })}
 
-          {showCutsiteLabels &&
-            showCutsites &&
+          <Labels
+            {...annotationCommonProps}
+            annotationRanges={[
+              ...(showCutsiteLabels && showCutsites
+                ? map(cutsites, a =>
+                    assign(a, {
+                      onClick: cutsiteClicked,
+                      onRightClick: cutsiteRightClicked
+                    })
+                  )
+                : []),
+              ...(showFeatureLabels && showFeatures
+                ? map(features, a =>
+                    assign(a, {
+                      onClick: featureClicked,
+                      onRightClick: featureRightClicked
+                    })
+                  )
+                : []),
+              ...(showPartLabels && showParts
+                ? map(parts, a =>
+                    assign(a, {
+                      onClick: partClicked,
+                      onRightClick: partRightClicked
+                    })
+                  )
+                : [])
+            ]}
+            annotationHeight={cutsiteLabelHeight}
+          />
+
+          {/* { &&
             Object.keys(cutsites).length > 0 && (
-              <CutsiteLabels
-                {...annotationCommonProps}
-                onClick={cutsiteClicked}
-                onRightClick={cutsiteRightClicked}
-                annotationRanges={cutsites}
-                annotationHeight={cutsiteLabelHeight}
-              />
-            )}
+            )} */}
 
           {showChromatogram && chromatogramData && (
             <Chromatogram


### PR DESCRIPTION
@ericsturman  This branch is not yet ready. A few things need to happen for it to be good to go: 

Here's what it looks like now: 
![image](https://user-images.githubusercontent.com/2730609/74971727-696b4a80-53d5-11ea-8ff9-5508d6f2120e.png)

- [ ] this UI choice should be able to be optionally toggled on/off via a prop 
- [ ] feature/part/cutsite labels should point to the center of the annotationRange 
- [ ] only one label should be drawn per feature/part/cutsite annotationRange per row 
- [ ] labels and label lines should reflect what happens in the Circular view 
        - [ ] lines always be shown but should be grey until hovered
- [ ] part lables should be purple 
- [ ] single cutter enzymes should be red
- [ ] we might want to make feature labels and cutsite labels more distinguishable like you suggested (via italicizing?)

Please let me know if you think of anything else to add to this list