### PR TITLE
fix 'Use GTG And CTG As Start Codons' checkbox status synchronizing between toolbar and properties table

### DIFF
--- a/src/helperComponents/PropertiesDialog/OrfProperties.js
+++ b/src/helperComponents/PropertiesDialog/OrfProperties.js
@@ -103,11 +103,13 @@ export default compose(
       annotationVisibility = {},
       sequenceData: { sequence = "" } = {},
       sequenceData,
-      minimumOrfSize
+      minimumOrfSize,
+      useAdditionalOrfStartCodons
     } = editorState;
     return {
       readOnly,
       annotationVisibility,
+      useAdditionalOrfStartCodons,
       orfs: selectors.orfsSelector(editorState),
       sequenceLength: sequence.length,
       sequenceData,


### PR DESCRIPTION
button on toolbar:
![image](https://user-images.githubusercontent.com/57167230/133358628-8f4eed36-619c-4902-ad7b-a8d96ea3365c.png)

button on properties table:
![image](https://user-images.githubusercontent.com/57167230/133358660-0d4cef10-b37d-4f3c-88e4-aa9474c3a90c.png)
