### PR TITLE
Allow the number input more flexible

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -873,7 +873,11 @@ const editCommandDefs = {
               props.annotationVisibilityShow("orfs");
               props.minimumOrfSizeUpdate(minimumOrfSize);
             }}
-            value={props.minimumOrfSize}
+            defaultValue={props.minimumOrfSize}
+            onBlur={function (event) {
+              // show the valid value in input when blurred
+              event.target.value = props.minimumOrfSize;
+            }}
           />
         </div>
       );


### PR DESCRIPTION
User may want to input any number they want in the ORFs input, but now we can not delete all the numbers in the input. This PR only make the input not a controlled React component to make the input more flexible.