### PR TITLE
Fixed Circular view title rotate issue. 

### DIFF
--- a/src/CircularView/index.js
+++ b/src/CircularView/index.js
@@ -508,6 +508,7 @@ export function CircularView(props) {
                 y={(-innerRadius * scale) / 2}
                 width={innerRadius * scale}
                 height={innerRadius * scale}
+                transform={`rotate(-${(rotationRadians * 180) / Math.PI})`}
               >
                 <div
                   xmlns="http://www.w3.org/1999/xhtml"

--- a/src/CircularView/style.css
+++ b/src/CircularView/style.css
@@ -17,6 +17,7 @@
 
 /*# sourceMappingURL= style.css.map */
 
-.veHideLabels .veLabels {
+.veHideLabels .veLabels,
+.veHideLabels .veCircularViewMiddleOfVectorText {
   display: none;
 }


### PR DESCRIPTION
@tnrich, We found that after the pre change, the title rotates with the Circular View. 
Try to rotate it back here.