### PR TITLE
Toggle 'Show ORF Translations' checkbox when enable/disable 'Show ORFs' checkbox in toolbar and properties tab

### DIFF
--- a/cypress/integration/orfs.spec.js
+++ b/cypress/integration/orfs.spec.js
@@ -55,7 +55,6 @@ describe("orfs", function () {
     cy.get(".bp3-control.bp3-checkbox:contains(7)").click({
       force: true
     });
-    cy.get(`[data-tab-id="translations"]`).click();
     cy.get(`[data-copy-text="260"]`).should("exist");
   });
 });

--- a/src/ToolBar/orfTool.js
+++ b/src/ToolBar/orfTool.js
@@ -14,8 +14,7 @@ import getCommands from "../commands";
 export default connectToEditor(
   ({ annotationVisibility = {}, toolBar = {} }) => {
     return {
-      orfsToggled: annotationVisibility.orfs,
-      orfTranslationsToggled: annotationVisibility.orfTranslations,
+      toggled: annotationVisibility.orfs,
       isOpen: toolBar.openItem === "orfTool"
     };
   }

--- a/src/ToolBar/orfTool.js
+++ b/src/ToolBar/orfTool.js
@@ -25,7 +25,6 @@ export default connectToEditor(
         Icon: <Icon data-test="orfTool" icon={orfIcon} />,
         onIconClick: function() {
           annotationVisibilityToggle("orfs");
-          annotationVisibilityToggle("orfTranslations");
         },
         toggled,
         tooltip: "Show Open Reading Frames",

--- a/src/ToolBar/orfTool.js
+++ b/src/ToolBar/orfTool.js
@@ -14,7 +14,8 @@ import getCommands from "../commands";
 export default connectToEditor(
   ({ annotationVisibility = {}, toolBar = {} }) => {
     return {
-      toggled: annotationVisibility.orfs,
+      orfsToggled: annotationVisibility.orfs,
+      orfTranslationsToggled: annotationVisibility.orfTranslations,
       isOpen: toolBar.openItem === "orfTool"
     };
   }

--- a/src/redux/annotationVisibility.js
+++ b/src/redux/annotationVisibility.js
@@ -135,7 +135,8 @@ const annotationVisibility = createMergedDefaultStateReducer(
     [annotationVisibilityToggle]: (state, payload) => {
       return {
         ...state,
-        [payload]: !state[payload]
+        [payload]: !state[payload],
+        ...(payload === 'orfs' && state['orfs'] === state['orfTranslations'] ? { orfTranslations: !state['orfTranslations'] } : null)
       };
     },
     [annotationVisibilityHide]: (state, payload) => {


### PR DESCRIPTION
Hi @tnrich , the ORF button on toolbar
![image](https://user-images.githubusercontent.com/57167230/139611230-ce2c4914-8dbe-42b8-92d1-07ef4517d00f.png)
 behavior differently (click this button will toggle two settings) with that on properties tab
![image](https://user-images.githubusercontent.com/57167230/139611251-68df0f5e-d324-4daa-b9ef-90e5064feccf.png)
