### PR TITLE
fix warning on css import order

### DIFF
--- a/src/Editor/style.css
+++ b/src/Editor/style.css
@@ -1,3 +1,5 @@
+@import url(darkmode.css);
+
 .veEditor {
   position: relative;
   flex-grow: 1;
@@ -78,7 +80,6 @@
   transform: scale(0.8);
 }
 
-@import url(darkmode.css);
 
 .veSearchLayer {
   cursor: pointer;


### PR DESCRIPTION
Fix following warning during vite build

![Screenshot from 2022-11-18 00-55-01](https://user-images.githubusercontent.com/38666763/202640208-7a130f86-e780-44e1-825f-92bf5d2fca06.png)
