### PR TITLE
fix(compat): fix compatibility for vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Teselagen's Open Source Vector Editor",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "exports": {
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "files": [
     "css",
     "es",


### PR DESCRIPTION
Hi @tnrich 

We need to modify the package.json file slightly in order to use open-vector-editor in vitest.

Vitest seems does not use "module" field in package.json. 
We have to add this "exports" field for it to resolve es modules correctly, otherwise it will resolve to the incorrect copy of file.