### PR TITLE
ssDNA should not show reverseSequence automaticlly 

### DIFF
--- a/src/helperComponents/PropertiesDialog/GenbankView.js
+++ b/src/helperComponents/PropertiesDialog/GenbankView.js
@@ -13,6 +13,9 @@ class GenbankView extends React.Component {
   state = {
     fileTypeToView: "genbank"
   };
+
+  select = () => this._input?.select();
+
   render() {
     const { sequenceData = {} } = this.props;
     let filestring;
@@ -48,7 +51,7 @@ class GenbankView extends React.Component {
         <textarea
           data-test="ve-genbank-text"
           readOnly
-          onclick="this.select()"
+          onClick={this.select}
           style={{
             whiteSpace: "pre",
             overflowWrap: "normal",
@@ -57,6 +60,7 @@ class GenbankView extends React.Component {
             fontFamily: "monospace",
             height: 350
           }}
+          ref={(ref) => (this._input = ref)}
           value={filestring}
         />
       </>

--- a/src/updateEditor.js
+++ b/src/updateEditor.js
@@ -1,4 +1,4 @@
-import { set } from "lodash";
+import { set, isEqual } from "lodash";
 import { tidyUpSequenceData } from "@teselagen/sequence-utils";
 import { annotationTypes } from "@teselagen/sequence-utils";
 
@@ -23,9 +23,19 @@ export default function updateEditor(
     currentEditor.sequenceData && currentEditor.sequenceData.isRna;
   const isAlreadyOligoEditor =
     currentEditor.sequenceData && currentEditor.sequenceData.isOligo;
+  const reverseSequenceShouldBeUpdate =
+    currentEditor.sequenceData?.isSingleStrandedDNA !==
+    sequenceData?.isSingleStrandedDNA;
+  const annotationVisibilityUpdated =
+    !isEqual(annotationVisibility, currentEditor.annotationVisibility) ||
+    !isEqual(annotationsToSupport, currentEditor.annotationsToSupport);
 
   const isAlreadySpecialEditor =
-    isAlreadyProteinEditor || isAlreadyRnaEditor || isAlreadyOligoEditor;
+    isAlreadyProteinEditor ||
+    isAlreadyRnaEditor ||
+    isAlreadyOligoEditor ||
+    reverseSequenceShouldBeUpdate ||
+    annotationVisibilityUpdated;
 
   let toSpread = {};
   let payload;
@@ -139,7 +149,7 @@ export default function updateEditor(
             caret: true,
             ...annotationVisibility, //we spread this here to allow the user to override this .. if they must!
             sequence: true,
-            reverseSequence: true,
+            reverseSequence: !sequenceData?.isSingleStrandedDNA,
             translations: false,
             aminoAcidNumbers: false,
             primaryProteinSequence: false


### PR DESCRIPTION
With this change and https://github.com/TeselaGen/tg-oss/pull/1
Reversed sequence does not show when drag a ss-DNA file in.
<img width="1472" alt="image" src="https://github.com/TeselaGen/openVectorEditor/assets/28696796/4f39503d-4d74-4177-b13d-09eb39a37ab9">
