### PR TITLE
Read only

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -342,46 +342,46 @@ export class Editor extends React.Component {
     const { previewModeFullscreen: uncontrolledPreviewModeFullscreen } =
       this.state;
     const {
-      ToolBarProps = {},
-      StatusBarProps = {},
-      extraRightSidePanel,
-      editorName,
-      height: _height,
-      showCircularity,
-      hideSingleImport,
-      minHeight = 400,
-      showMenuBar,
+      allowPanelTabDraggable = true,
       annotationsToSupport,
-      withRotateCircularView = true,
-      withZoomCircularView = true,
-      withZoomLinearView = true,
-      displayMenuBarAboveTools = true,
-      updateSequenceData,
-      readOnly,
-      setPanelAsActive,
-      style = {},
-      maxAnnotationsToDisplay,
-      togglePanelFullScreen,
-      collapseSplitScreen,
-      expandTabToSplitScreen,
-      closePanel,
-      onSave,
-      hideStatusBar,
       caretPositionUpdate,
+      closePanel,
+      collapseSplitScreen,
+      displayMenuBarAboveTools = true,
+      editorName,
+      expandTabToSplitScreen,
+      extraRightSidePanel,
+      fullScreenOffsets,
       getVersionList,
       getSequenceAtVersion,
-      selectionLayer,
-      VersionHistoryViewProps,
-      sequenceData = {},
-      fullScreenOffsets,
-      withPreviewMode,
-      isFullscreen,
-      hoveredId,
       handleFullscreenClose,
+      height: _height,
+      hideSingleImport,
+      hideStatusBar,
+      hoveredId,
+      isFullscreen,
+      maxAnnotationsToDisplay,
+      minHeight = 400,
       onlyShowLabelsThatDoNotFit = true,
+      onSave,
       previewModeFullscreen: controlledPreviewModeFullscreen,
       previewModeButtonMenu,
-      allowPanelTabDraggable = true
+      readOnly,
+      selectionLayer,
+      sequenceData = {},
+      setPanelAsActive,
+      showCircularity,
+      showMenuBar,
+      style = {},
+      StatusBarProps = {},
+      togglePanelFullScreen,
+      ToolBarProps = {},
+      updateSequenceData,
+      VersionHistoryViewProps,
+      withPreviewMode,
+      withRotateCircularView = true,
+      withZoomCircularView = true,
+      withZoomLinearView = true
     } = this.props;
     if (
       !this.props.noVersionHistory &&
@@ -904,6 +904,7 @@ export class Editor extends React.Component {
               editorName
             }}
             withDigestTool
+            onChangeEditLock={this.props.onChangeEditLock}
             {...ToolBarProps}
           />
 

--- a/src/ToolBar/editTool.js
+++ b/src/ToolBar/editTool.js
@@ -1,5 +1,5 @@
-import { Icon } from "@blueprintjs/core";
 import React from "react";
+import { Icon } from "@blueprintjs/core";
 import ToolbarItem from "./ToolbarItem";
 import { connectToEditor } from "../withEditorProps";
 
@@ -8,17 +8,19 @@ export default connectToEditor((editorState) => {
     readOnly: editorState.readOnly
   };
 })(({ toolbarItemProps, readOnly, toggleReadOnlyMode, disableSetReadOnly }) => {
+  const readOnlyTooltip = ({ readOnly, disableSetReadOnly }) => {
+    if (disableSetReadOnly) {
+      return "You do not have permission to edit locks on this sequence";
+    }
+    return readOnly ? "Click to enable editing" : "Click to disable editing";
+  };
   return (
     <ToolbarItem
       {...{
         disabled: disableSetReadOnly,
         Icon: <Icon icon={readOnly ? "lock" : "unlock"} />,
         onIconClick: toggleReadOnlyMode,
-        tooltip: readOnly ? (
-          <span>Switch to edit mode</span>
-        ) : (
-          <span>Switch to read only mode</span>
-        ),
+        tooltip: readOnlyTooltip({ readOnly, disableSetReadOnly }),
         ...toolbarItemProps
       }}
     />

--- a/src/ToolBar/editTool.js
+++ b/src/ToolBar/editTool.js
@@ -7,22 +7,33 @@ export default connectToEditor((editorState) => {
   return {
     readOnly: editorState.readOnly
   };
-})(({ toolbarItemProps, readOnly, toggleReadOnlyMode, disableSetReadOnly }) => {
-  const readOnlyTooltip = ({ readOnly, disableSetReadOnly }) => {
-    if (disableSetReadOnly) {
-      return "You do not have permission to edit locks on this sequence";
-    }
-    return readOnly ? "Click to enable editing" : "Click to disable editing";
-  };
-  return (
-    <ToolbarItem
-      {...{
-        disabled: disableSetReadOnly,
-        Icon: <Icon icon={readOnly ? "lock" : "unlock"} />,
-        onIconClick: toggleReadOnlyMode,
-        tooltip: readOnlyTooltip({ readOnly, disableSetReadOnly }),
-        ...toolbarItemProps
-      }}
-    />
-  );
-});
+})(
+  ({
+    toolbarItemProps,
+    readOnly,
+    toggleReadOnlyMode,
+    disableSetReadOnly,
+    onChangeEditLock = () => {}
+  }) => {
+    const readOnlyTooltip = ({ readOnly, disableSetReadOnly }) => {
+      if (disableSetReadOnly) {
+        return "You do not have permission to edit locks on this sequence";
+      }
+      return readOnly ? "Click to enable editing" : "Click to disable editing";
+    };
+    return (
+      <ToolbarItem
+        {...{
+          disabled: disableSetReadOnly,
+          Icon: <Icon icon={readOnly ? "lock" : "unlock"} />,
+          onIconClick: () => {
+            onChangeEditLock(!readOnly);
+            toggleReadOnlyMode();
+          },
+          tooltip: readOnlyTooltip({ readOnly, disableSetReadOnly }),
+          ...toolbarItemProps
+        }}
+      />
+    );
+  }
+);

--- a/src/redux/readOnly.js
+++ b/src/redux/readOnly.js
@@ -19,7 +19,7 @@ export default createReducer(
     [updateReadOnlyMode]: (state, payload) => {
       return payload;
     },
-    [toggleReadOnlyMode]: state => {
+    [toggleReadOnlyMode]: (state) => {
       return !state;
     }
   },


### PR DESCRIPTION
Added tooltip dialogue when edit lock is disabled.
Added onChangeEditLock parameter. It is a function that runs when the editLock button is pressed, it receives the value of readOnly that you are changing into:
`onChangeEditLock(!readOnly);`
